### PR TITLE
use numeric reference superscript instead of named

### DIFF
--- a/quickstart_tutorial_borealis.ipynb
+++ b/quickstart_tutorial_borealis.ipynb
@@ -24,7 +24,7 @@
     "*Authors: Theodor Isacsson and Isaac De Vlugt*\n",
     "\n",
     "In this quickstart, we will show how Xanadu's new Borealis quantum hardware can be programmed in minutes.\n",
-    "Borealis showcases quantum computational advantage, as can be seen in our publication in [Nature](https://xanadu.ai/qca-paper)[<sup>#advantage2022</sup>](#advantage2022) --- meaning that it can compute in seconds quantities that would require years on the fastest available supercomputer.\n",
+    "Borealis showcases quantum computational advantage, as can be seen in our publication in [Nature](https://xanadu.ai/qca-paper)[<sup>1</sup>](#advantage2022) --- meaning that it can compute in seconds quantities that would require years on the fastest available supercomputer.\n",
     "It's hardware is based on [time-domain multiplexing (TDM)](https://strawberryfields.ai/photonics/demos/run_time_domain.html);\n",
     "a single squeezed-light source emits batches of 216 time-ordered squeezed-light \n",
     "pulses that interfere with one another with the help of optical delay loops, \n",
@@ -150,7 +150,7 @@
     "<h2>References</h2>\n",
     "\n",
     "\n",
-    "<span id=\"advantage2022\">[advantage2022]</span>: <i>Madsen, L.S., Laudenbach, F., Askarani, M.F. et al.</i> \"Quantum computational advantage with a programmable photonic processor\", <a href=\"https://www.nature.com/articles/s41586-022-04725-x\">Nature 606, 75-81</a>, 2022"
+    "<span id=\"advantage2022\">[1]</span>: <i>Madsen, L.S., Laudenbach, F., Askarani, M.F. et al.</i> \"Quantum computational advantage with a programmable photonic processor\", <a href=\"https://www.nature.com/articles/s41586-022-04725-x\">Nature 606, 75-81</a>, 2022"
    ]
   },
   {


### PR DESCRIPTION
the internal naming of the hyperlink is still `advantage2022` for legibility, but it just shows up as a `1` now. (the hyperlink doesn't work on the github preview but I confirmed it in other envs) 